### PR TITLE
fix: handle incorrect symbols

### DIFF
--- a/lib/ex_twelve_data/real_time_prices.ex
+++ b/lib/ex_twelve_data/real_time_prices.ex
@@ -61,7 +61,10 @@ defmodule ExTwelveData.RealTimePrices do
       {"X-TD-APIKEY", api_key}
     ]
 
-    Keyword.merge([ssl_options: ssl_options, extra_headers: extra_headers, insecure: false], opts)
+    Keyword.merge(
+      [ssl_options: ssl_options, extra_headers: extra_headers, insecure: false],
+      opts
+    )
   end
 
   @doc """
@@ -161,7 +164,7 @@ defmodule ExTwelveData.RealTimePrices do
 
       _ ->
         Logger.error("Received heartbeat with status: #{status}")
-        :close
+        :stop
     end
   end
 
@@ -178,7 +181,7 @@ defmodule ExTwelveData.RealTimePrices do
 
       _ ->
         Logger.error("Subscribe failed with status: #{status}")
-        :close
+        :ok
     end
   end
 
@@ -195,7 +198,7 @@ defmodule ExTwelveData.RealTimePrices do
 
       _ ->
         Logger.error("Unsubscribe failed with status: #{status}")
-        :close
+        :stop
     end
   end
 
@@ -212,7 +215,7 @@ defmodule ExTwelveData.RealTimePrices do
 
       _ ->
         Logger.error("Reset failed with status: #{status}")
-        :close
+        :stop
     end
   end
 

--- a/lib/ex_twelve_data/real_time_prices/supervisor.ex
+++ b/lib/ex_twelve_data/real_time_prices/supervisor.ex
@@ -1,0 +1,34 @@
+defmodule ExTwelveData.Supervisor do
+  use Supervisor
+
+  @type options :: [option]
+
+  @type option ::
+          ExTwelveData.RealTimePrices.option()
+          | ExTwelveData.RealTimePrices.SubscriptionsManager.option()
+
+  @spec start_link(options) :: {:error, any} | {:ok, pid}
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(opts) do
+    realtime_prices_name = ExTwelveData.RealTimePrices1
+
+    realtime_prices_options =
+      Keyword.merge(
+        [name: realtime_prices_name],
+        Keyword.drop(opts, [:name])
+      )
+
+    subscriptions_manager_options =
+      Keyword.merge([pid: realtime_prices_name], Keyword.drop(opts, [:name]))
+
+    children = [
+      {ExTwelveData.RealTimePrices, realtime_prices_options},
+      {ExTwelveData.RealTimePrices.SubscriptionsManager, subscriptions_manager_options}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+end

--- a/lib/ex_twelve_data/real_time_prices/supervisor.ex
+++ b/lib/ex_twelve_data/real_time_prices/supervisor.ex
@@ -1,4 +1,15 @@
 defmodule ExTwelveData.Supervisor do
+  @moduledoc """
+  Supervisor for the RealTimePrices and SubscriptionsManager processes.
+
+  It starts the RealTimePrices and SubscriptionsManager processes, and restarts them if they crash.
+  This is important since the RealTimePrices client has an implicit state with the Twelve Data connection:
+  the list of symbols that are subscribed to is determined by the sequence of subscribe/unsubscribe messages.
+  If the RealTimePrices process crashes, the state is lost, and the list of subscribed symbols is reset.
+  This supervisor ensures that when the RealTimePrices process crashes,
+  it is restarted with a fresh SubscriptionManager process, which will then have a clean state,
+  and restart the entire flow.
+  """
   use Supervisor
 
   @type options :: [option]
@@ -13,7 +24,7 @@ defmodule ExTwelveData.Supervisor do
   end
 
   def init(opts) do
-    realtime_prices_name = ExTwelveData.RealTimePrices1
+    realtime_prices_name = ExTwelveData.RealTimePrices.Supervised
 
     realtime_prices_options =
       Keyword.merge(

--- a/lib/ex_twelve_data/symbol.ex
+++ b/lib/ex_twelve_data/symbol.ex
@@ -1,4 +1,8 @@
 defmodule ExTwelveData.Symbol do
+  @moduledoc """
+  Struct to represent a Twelve Data extended symbol.
+  """
+
   @derive Jason.Encoder
   defstruct [
     :exchange,

--- a/test/integration.exs
+++ b/test/integration.exs
@@ -9,17 +9,9 @@ defmodule MockHandler do
   end
 end
 
-{:ok, pid} =
-  ExTwelveData.RealTimePrices.start_link(
-    api_key: System.fetch_env!("TWELVE_DATA_API_KEY"),
-    handler: MockHandler
-  )
-
-alias ExTwelveData.RealTimePrices.SubscriptionsManager
-
 defmodule MockProvider do
   alias ExTwelveData.Symbol
-  @behaviour SubscriptionsManager.Provider
+  @behaviour ExTwelveData.RealTimePrices.SubscriptionsManager.Provider
 
   require Logger
 
@@ -47,11 +39,12 @@ defmodule MockProvider do
   end
 end
 
-SubscriptionsManager.start_link(
-  pid: pid,
+ExTwelveData.Supervisor.start_link(
   provider: MockProvider,
   max_subscriptions: 8,
-  symbols_extended: true
+  symbols_extended: true,
+  api_key: System.fetch_env!("TWELVEDATA_APIKEY"),
+  handler: MockHandler
 )
 
 # ["AAPL", "MSFT", "GOOG"],


### PR DESCRIPTION
- Replace `close` with `stop`
- Introduce supervisor to manage processes